### PR TITLE
composer.json: tenebras/Kalibri -> tenebras/kalibri

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "tenebras/Kalibri",
+    "name": "tenebras/kalibri",
     "type": "framework",
     "description": "Lightweight PHP framework",
     "keywords": ["framework","lightweight"],


### PR DESCRIPTION
The package name tenebras/Kalibri is invalid, it should not contain uppercase characters. We suggest using tenebras/kalibri instead.
